### PR TITLE
allow customization of the port (and host name) for the redirection URI

### DIFF
--- a/webapi/private/oauth2-web.rkt
+++ b/webapi/private/oauth2-web.rkt
@@ -21,7 +21,7 @@ TO DO:
 |#
 
 (define (generate-redirect-uri host port)
-  (string-append "http://" host ":" (number->string port) "/oauth2/response"))
+  (string-append "http://" host ":" (number->string port) "/oauth2/response")))
 
 (define (oauth2/request-auth-code/browser auth-server client scopes 
          #:host [host "localhost"]

--- a/webapi/private/oauth2-web.rkt
+++ b/webapi/private/oauth2-web.rkt
@@ -20,36 +20,42 @@ TO DO:
  - try oauth2/request-access/browser again
 |#
 
-(define (oauth2/request-auth-code/browser auth-server client scopes)
+(define (oauth2/request-auth-code/browser auth-server client scopes 
+         #:redirect-uri [redirect-uri "http://localhost:8000/oauth2/response"]
+         #:port [port 8000])
   (let ([oauth2 (new oauth2%
                      (auth-server auth-server)
                      (client client))])
-    (let ([auth-code (request-auth-code/web oauth2 scopes)])
+    (let ([auth-code (request-auth-code/web oauth2 scopes 
+                      #:port port 
+                      #:redirect-uri redirect-uri)])
       (send oauth2 acquire-token/auth-code!
             auth-code
-            #:redirect-uri "http://localhost:8000/oauth2/response"
+            #:redirect-uri redirect-uri
             #:who 'oauth2/request-access/web)
       oauth2)))
 
 (define (request-auth-code/web oauth2 scopes
-                               #:who [who 'request-access/web])
+                               #:who [who 'request-access/web]
+                               #:port [port 8000]
+                               #:redirect-uri [redirect-uri "http://localhost:8000/oauth2/response"])
   (let ([chan (make-channel)]
         [server-cust (make-custodian)])
     (parameterize ((current-custodian server-cust))
       (thread
        (lambda ()
-         (serve/servlet (make-servlet oauth2 scopes chan)
+         (serve/servlet (make-servlet oauth2 scopes chan #:redirect-uri redirect-uri)
                         #:launch-browser? #t
                         #:quit? #t
                         #:banner? #f
-                        #:port 8000
+                        #:port port
                         #:servlet-path "/oauth2/init"
                         #:servlet-regexp #rx"^/oauth2/"
                         #:extra-files-paths null))))
     (begin0 (channel-get chan)
       (custodian-shutdown-all server-cust))))
 
-(define (make-servlet oauth2 scopes chan)
+(define (make-servlet oauth2 scopes chan #:redirect-uri [redirect-uri "http://localhost:8000/oauth2/response"])
   (lambda (req)
     (let ([path (string-join (map path/param-path (url-path (request-uri req))) "/")])
       (cond [(equal? path "oauth2/init")
@@ -59,7 +65,7 @@ TO DO:
                 (send auth-server get-auth-request-url
                       #:client client
                       #:scopes scopes
-                      #:redirect-uri "http://localhost:8000/oauth2/response")))]
+                      #:redirect-uri redirect-uri)))]
             [(equal? path "oauth2/response")
              (let ([bindings (request-bindings/raw req)])
                (cond [(bindings-assq #"code" bindings)

--- a/webapi/private/oauth2-web.rkt
+++ b/webapi/private/oauth2-web.rkt
@@ -21,7 +21,7 @@ TO DO:
 |#
 
 (define (generate-redirect-uri host port)
-  (string-append "http://" host ":" (number->string port) "/oauth2/response")))
+  (string-append "http://" host ":" (number->string port) "/oauth2/response"))
 
 (define (oauth2/request-auth-code/browser auth-server client scopes 
          #:host [host "localhost"]
@@ -68,7 +68,7 @@ TO DO:
                 (send auth-server get-auth-request-url
                       #:client client
                       #:scopes scopes
-                      #:redirect-uri (generate-redirect-uri host port)))]
+                      #:redirect-uri (generate-redirect-uri host port))))]
             [(equal? path "oauth2/response")
              (let ([bindings (request-bindings/raw req)])
                (cond [(bindings-assq #"code" bindings)

--- a/webapi/scribblings/oauth2.scrbl
+++ b/webapi/scribblings/oauth2.scrbl
@@ -293,7 +293,9 @@ Obtain an instance via @racket[oauth2/request-auth-code/browser],
 @defproc[(oauth2/request-auth-code/browser
              [auth-server (is-a?/c oauth2-auth-server<%>)]
              [client (is-a?/c oauth2-client<%>)]
-             [scopes (listof string?)])
+             [scopes (listof string?)]
+             [#:port port number? 8000]
+             [#:host host string? "localhost"])
          (is-a?/c oauth2<%>)]{
 
   Automates the combination of @method[oauth2-auth-server<%>
@@ -302,6 +304,14 @@ Obtain an instance via @racket[oauth2/request-auth-code/browser],
   @tt{localhost:8000} and supplying a redirection URL of
   @racket["http://localhost:8000/oauth2/response"] in the
   authorization code request to @racket[auth-server].
+  
+  You can customize the redirection URL using the optional
+  keyword arguments @racket[#:port] and @racket[#:host]. Changing 
+  the @racket[port] number will cause the ad hoc web server to 
+  operate on a different port. Changing the @racket[host] to 
+  anything other than @racket["127.0.0.1"] is likely nonsensical, 
+  but such changes may be necessary to make this procedure work 
+  with certain services.
 }
 
 @section[#:tag "oauth2-security"]{OAuth 2.0 Security Notes}


### PR DESCRIPTION
To get this library to work with Clio (https://app.clio.com/api/v4/documentation), I needed to change the redirect URI from "localhost" to "127.0.0.1". This pull request contains these changes (and updates to the documentation).